### PR TITLE
Allow newer laravel versions - 6 and upper

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "illuminate/support": "5.*",
+        "illuminate/support": ">=5.5",
         "intervention/imagecache": "2.*"
     },
     "autoload": {


### PR DESCRIPTION
As laravel was changed to semver, we mark for illuminate/support dependency any version upper to 5.5 as compatible instead of only the 5.* range